### PR TITLE
Custom log targets

### DIFF
--- a/ext/easylogging-8.91/easylogging++.h
+++ b/ext/easylogging-8.91/easylogging++.h
@@ -2261,20 +2261,6 @@ public:
         customTargets_.push_back(target);
     }
 
-    struct ShouldDelete {
-        ShouldDelete(ILogTarget* cur)
-            : cur_(cur)
-        {
-        }
-
-        bool operator()(const ILogTarget* cand) const {
-            return cur_ == cand;
-        }
-
-    private:
-        ILogTarget* cur_;
-    };
-
     inline void removeLogTarget(ILogTarget* target) {
         customTargets_.remove_if(ShouldDelete(target));
     }
@@ -2293,7 +2279,22 @@ public:
     private:
         std::string id_;
     };
+
 private:
+    struct ShouldDelete {
+        ShouldDelete(ILogTarget* cur)
+            : cur_(cur)
+        {
+        }
+
+        bool operator()(const ILogTarget* cand) const {
+            return cur_ == cand;
+        }
+
+    private:
+        ILogTarget* cur_;
+    };
+
     std::string id_;
     internal::Constants* constants_;
     Configurations userConfigurations_;

--- a/ext/easylogging-8.91/easylogging++.h
+++ b/ext/easylogging-8.91/easylogging++.h
@@ -2262,7 +2262,7 @@ public:
     }
 
     inline void removeLogTarget(ILogTarget* target) {
-        customTargets_.remove_if(ShouldDelete(target));
+        customTargets_.remove(target);
     }
 
     //!
@@ -2281,20 +2281,6 @@ public:
     };
 
 private:
-    struct ShouldDelete {
-        ShouldDelete(ILogTarget* cur)
-            : cur_(cur)
-        {
-        }
-
-        bool operator()(const ILogTarget* cand) const {
-            return cur_ == cand;
-        }
-
-    private:
-        ILogTarget* cur_;
-    };
-
     std::string id_;
     internal::Constants* constants_;
     Configurations userConfigurations_;

--- a/tests/test-client/main.cpp
+++ b/tests/test-client/main.cpp
@@ -60,6 +60,42 @@ struct CurlGlobal
     }
 };
 
+class CustomLogTarget : public easyloggingpp::ILogTarget
+{
+public:
+    CustomLogTarget()
+        : count_(0)
+    {
+    }
+
+    void log(const std::string& msg) {
+        ++count_;
+        std::cout << "log(" << count_ << "): " << msg << std::endl;
+    }
+
+private:
+    int count_;
+};
+
+// TODO: move to easyloggingpp code
+class ScopedLogTarget
+{
+public:
+    ScopedLogTarget(easyloggingpp::ILogTarget* target)
+        : target_(target)
+    {
+        easyloggingpp::Loggers::addLogTarget(target);
+    }
+
+    ~ScopedLogTarget()
+    {
+        easyloggingpp::Loggers::removeLogTarget(target_.get());
+    }
+
+private:
+    prc::unique_ptr<easyloggingpp::ILogTarget>::t target_;
+};
+
 bool findInstrumentByName(prc::Client& client, int accountId,
                           const std::string& cameraName, prc::Instrument& instrument)
 {
@@ -98,6 +134,7 @@ int main(int argc, char** argv)
         return -1;
     }
 
+    ScopedLogTarget logTarget(new CustomLogTarget());
     initLogger();
 
     std::string cameraName(argv[1]);

--- a/tests/test-client/main.cpp
+++ b/tests/test-client/main.cpp
@@ -77,17 +77,16 @@ private:
     int count_;
 };
 
-// TODO: move to easyloggingpp code
-class ScopedLogTarget
+class ScopedLogTargetGuard
 {
 public:
-    ScopedLogTarget(easyloggingpp::ILogTarget* target)
+    ScopedLogTargetGuard(easyloggingpp::ILogTarget* target)
         : target_(target)
     {
         easyloggingpp::Loggers::addLogTarget(target);
     }
 
-    ~ScopedLogTarget()
+    ~ScopedLogTargetGuard()
     {
         easyloggingpp::Loggers::removeLogTarget(target_.get());
     }
@@ -134,7 +133,7 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    ScopedLogTarget logTarget(new CustomLogTarget());
+    ScopedLogTargetGuard logTarget(new CustomLogTarget());
     initLogger();
 
     std::string cameraName(argv[1]);


### PR DESCRIPTION
Now it's possible to add custom log targets (in addition to std::cout and tofile).

Test is added to test-client.