### PR TITLE
EDGE-517 Switch VirtCam to ConnectSDK v1.12.1

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1169,7 +1169,8 @@ CurlSessionPtr Client::Impl::createSession()
         session.setLowSpeed(lowSpeedTime_, lowSpeedLimit_);
         session.setSslVerifyPeer(sslVerifyPeer_);
         session.setProxy(proxy_);
-        session.setCaBundlePath(caBundlePath_);
+        if (!caBundlePath_.empty())
+            session.setCaBundlePath(caBundlePath_);
     }
 
     return boost::move(sessionPtr);

--- a/version.cmake
+++ b/version.cmake
@@ -1,4 +1,4 @@
 # Copyright (C) 2017 Prism Skylabs
 set(ConnectSDK_VERSION_MAJOR 1)
 set(ConnectSDK_VERSION_MINOR 12)
-set(ConnectSDK_VERSION_REVISION 1)
+set(ConnectSDK_VERSION_REVISION 2)


### PR DESCRIPTION
Actually, it is not switching VirtCam to ConnectSDK v1.12.1
It is a bug fix in ConnectSDK related to EDGE-517