### PR TITLE
EDGE-576 Connect SDK fails to build on MacOS

### DIFF
--- a/platforms/shared/examples/yt_camera/CMakeLists.txt
+++ b/platforms/shared/examples/yt_camera/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (C) 2016-2017 Prism Skylabs
-find_package(OpenCV 3.1 REQUIRED)
+findOpencvCommon()
 
 include_directories(
     ${CONNECT_INCLUDE_DIRS}

--- a/platforms/shared/shared.cmake
+++ b/platforms/shared/shared.cmake
@@ -72,8 +72,7 @@ macro(setFlagsCommon)
 endmacro()
 
 macro(findOpencvCommon)
-    # the message will be removed as soon as EDGE-280 is fixed
-    message(FATAL_ERROR "Not implemented")
+    # While EDGE-280 is still open, test app loads successfully
     if (NOT DEFINED ENV{OPENCV_ROOT})
         set(OPENCV_ROOT ${PROJECT_SOURCE_DIR}/ext/opencv_${PRISM_PLATFORM}_${OPENCV_VERSION})
         download_artifact("${ARTIFACTORY_URL}/libs-release-public" "${PRISM_PLATFORM}" opencv "${OPENCV_VERSION}" "${OPENCV_ROOT}")

--- a/platforms/shared/tests/test-client/CMakeLists.txt
+++ b/platforms/shared/tests/test-client/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (C) 2016-2017 Prism Skylabs
-find_package(OpenCV 3.1 REQUIRED)
+findOpencvCommon()
 
 include_directories(
     ${CONNECT_INCLUDE_DIRS}


### PR DESCRIPTION
Reason was that searching for OpenCV from artifactory was disabled, because of EDGE-208
The fix is to enable using OpenCV from artifactory. Problem described in EDGE-208 isn't
reproduced.