### PR TITLE
EDGE-628 Curl long timeout if server is unavailable

### DIFF
--- a/include/private/curl-wrapper.h
+++ b/include/private/curl-wrapper.h
@@ -135,7 +135,7 @@ public:
 
     void setConnectionTimeoutMs(long timeoutMs)
     {
-        curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT, timeoutMs);
+        curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT_MS, timeoutMs);
     }
 
     void setLowSpeed(long lowSpeedTime, long lowSpeedLimit)


### PR DESCRIPTION
Replaced CURLOPT_CONNECTTIMEOUT with CURLOPT_CONNECTTIMEOUT_MS