### PR TITLE
CV-456 Track.objectId values are negative

### DIFF
--- a/include/domain-types.h
+++ b/include/domain-types.h
@@ -259,13 +259,13 @@ typedef std::vector<TrackPoint> TrackPoints;
 
 struct Track
 {
-    Track(int objectId, const timestamp_t& timestamp)
+    Track(int64_t objectId, const timestamp_t& timestamp)
         : objectId(objectId)
         , timestamp(timestamp)
     {
     }
 
-    int objectId;
+    int64_t objectId;
     timestamp_t timestamp;
     TrackPoints points;
 };

--- a/platforms/shared/tests/test-client/main.cpp
+++ b/platforms/shared/tests/test-client/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Prism Skylabs
+ * Copyright (C) 2016-2018 Prism Skylabs
  */
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <limits>
 #include <boost/filesystem.hpp>
 #include "client.h"
 #include "curl/curl.h"
@@ -156,12 +157,14 @@ void testUploadCount(prc::Client& client, prc::id_t accountId, prc::id_t instrum
 void testUploadTracks(prc::Client& client, prc::id_t accountId, prc::id_t instrumentId)
 {
     prc::Tracks tracks;
-    tracks.push_back(prc::Track(0, prism::test::generateTimestamp()));
+    tracks.push_back(prc::Track(std::numeric_limits<int64_t>::max() - 2,
+                                prism::test::generateTimestamp()));
     prc::TrackPoints& ptsOne = tracks.back().points;
     ptsOne.push_back(prc::TrackPoint(0, 100, 0));
     ptsOne.push_back(prc::TrackPoint(123, 588, 20));
     ptsOne.push_back(prc::TrackPoint(300, 430, 50));
-    tracks.push_back(prc::Track(2, prism::test::generateTimestamp()));
+    tracks.push_back(prc::Track(std::numeric_limits<int64_t>::max(),
+                                prism::test::generateTimestamp()));
     prc::TrackPoints& ptsTwo = tracks.back().points;
     ptsTwo.push_back(prc::TrackPoint(360, 240, 0));
     ptsTwo.push_back(prc::TrackPoint(320, 120, 67));
@@ -265,8 +268,8 @@ int main(int argc, char** argv)
     LOG(INFO) << "Instrument ID: " << instrumentId;
 
     testUploadCount(client, accountId, instrumentId);
-    return 0;
     testUploadTracks(client, accountId, instrumentId);
+    return 0;
 
     // Open video stream
     VideoCapture cap(inputFile.c_str());

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -280,7 +280,7 @@ std::string toJsonString(const Tracks& tracks)
     {
         JsonValue jsonTrack(allocator);
         const Track track = tracks[i];
-        jsonTrack.addMember(kStrObjectId, track.objectId);
+        jsonTrack.addMember(kStrObjectId, std::to_string(track.objectId));
         jsonTrack.addMember(kStrTimestamp, toIsoTimeString(track.timestamp));
 
         JsonValue jsonPoints(allocator, true);


### PR DESCRIPTION
Track IDs in virtual camera are now int64, but in Connect SDK they are int.
Switched to using int64 as track ID in Connect SDK and sending track ID in JSON
as a string, rather than a number (integer number can only have 53 bits).